### PR TITLE
Prohibit throwing Error in generateTests and check

### DIFF
--- a/src/main/java/org/hyperskill/hstest/dev/exception/FailureHandler.java
+++ b/src/main/java/org/hyperskill/hstest/dev/exception/FailureHandler.java
@@ -156,7 +156,7 @@ public class FailureHandler {
             circularLinks.toString() + "\n";
     }
 
-    public static String getFeedback(Exception ex, int currTest) {
+    public static String getFeedback(Throwable ex, int currTest) {
 
         String errorText;
         String stackTraceInfo;

--- a/src/main/java/org/hyperskill/hstest/dev/exception/FailureHandler.java
+++ b/src/main/java/org/hyperskill/hstest/dev/exception/FailureHandler.java
@@ -156,18 +156,18 @@ public class FailureHandler {
             circularLinks.toString() + "\n";
     }
 
-    public static String getFeedback(Throwable ex, int currTest) {
+    public static String getFeedback(Throwable t, int currTest) {
 
         String errorText;
         String stackTraceInfo;
-        if (ex.getCause() != null &&
-            ex instanceof InvocationTargetException) {
-            // If user failed then ex == InvocationTargetException
-            // and ex.getCause() == Actual user exception
+        if (t.getCause() != null &&
+            t instanceof InvocationTargetException) {
+            // If user failed then t == InvocationTargetException
+            // and t.getCause() == Actual user exception
             errorText = "Exception in test #" + currTest;
-            stackTraceInfo = filterStackTrace(getStackTrace(ex.getCause()));
+            stackTraceInfo = filterStackTrace(getStackTrace(t.getCause()));
 
-            Throwable cause = ex.getCause();
+            Throwable cause = t.getCause();
 
             if (cause instanceof InputMismatchException
                 && stackTraceInfo.contains("java.util.Scanner")) {
@@ -193,15 +193,15 @@ public class FailureHandler {
                 errorText += "\n\n" + avoidStaticsMsg;
             }
 
-        } else if (ex instanceof FileSystemException) {
+        } else if (t instanceof FileSystemException) {
 
             errorText = "Error in test #" + currTest ;
             stackTraceInfo = "";
 
             // without "class "
-            String exceptionName = ex.getClass().toString().substring(6);
+            String exceptionName = t.getClass().toString().substring(6);
 
-            String file = ((FileSystemException) ex).getFile();
+            String file = ((FileSystemException) t).getFile();
 
             if (file.startsWith(Utils.CURRENT_DIR)) {
                 file = file.substring(Utils.CURRENT_DIR.length());
@@ -222,11 +222,11 @@ public class FailureHandler {
 
             errorText = "Fatal error " + whenErrorHappened +
                 ", please send the report to Hyperskill team.\n\n" + getReport();
-            if (ex.getCause() == null) {
-                stackTraceInfo = getStackTrace(ex);
+            if (t.getCause() == null) {
+                stackTraceInfo = getStackTrace(t);
             } else {
-                stackTraceInfo = getStackTrace(ex) +
-                    "\n" + getStackTrace(ex.getCause());
+                stackTraceInfo = getStackTrace(t) +
+                    "\n" + getStackTrace(t.getCause());
             }
         }
 

--- a/src/main/java/org/hyperskill/hstest/dev/stage/BaseStageTest.java
+++ b/src/main/java/org/hyperskill/hstest/dev/stage/BaseStageTest.java
@@ -194,7 +194,7 @@ public abstract class BaseStageTest<AttachType> implements StageTest {
                     assertTrue(errorMessage, result.isCorrect());
                 }
             }
-        } catch (Exception | Error ex) {
+        } catch (Throwable ex) {
             fail(FailureHandler.getFeedback(ex, currTest));
         }
     }

--- a/src/main/java/org/hyperskill/hstest/dev/stage/BaseStageTest.java
+++ b/src/main/java/org/hyperskill/hstest/dev/stage/BaseStageTest.java
@@ -20,8 +20,7 @@ import java.util.Locale;
 import java.util.concurrent.ExecutorService;
 
 import static org.hyperskill.hstest.dev.common.Utils.*;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 import static org.junit.contrib.java.lang.system.TextFromStandardInputStream.emptyStandardInputStream;
 
 public abstract class BaseStageTest<AttachType> implements StageTest {

--- a/src/main/java/org/hyperskill/hstest/dev/stage/BaseStageTest.java
+++ b/src/main/java/org/hyperskill/hstest/dev/stage/BaseStageTest.java
@@ -20,7 +20,8 @@ import java.util.Locale;
 import java.util.concurrent.ExecutorService;
 
 import static org.hyperskill.hstest.dev.common.Utils.*;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.junit.contrib.java.lang.system.TextFromStandardInputStream.emptyStandardInputStream;
 
 public abstract class BaseStageTest<AttachType> implements StageTest {
@@ -194,7 +195,7 @@ public abstract class BaseStageTest<AttachType> implements StageTest {
                     assertTrue(errorMessage, result.isCorrect());
                 }
             }
-        } catch (Exception ex) {
+        } catch (Exception | Error ex) {
             fail(FailureHandler.getFeedback(ex, currTest));
         }
     }

--- a/src/main/java/org/hyperskill/hstest/dev/stage/BaseStageTest.java
+++ b/src/main/java/org/hyperskill/hstest/dev/stage/BaseStageTest.java
@@ -194,8 +194,8 @@ public abstract class BaseStageTest<AttachType> implements StageTest {
                     assertTrue(errorMessage, result.isCorrect());
                 }
             }
-        } catch (Throwable ex) {
-            fail(FailureHandler.getFeedback(ex, currTest));
+        } catch (Throwable t) {
+            fail(FailureHandler.getFeedback(t, currTest));
         }
     }
 

--- a/src/test/java/outcomes/FatalErrorDuringCheckingWithAssertion.java
+++ b/src/test/java/outcomes/FatalErrorDuringCheckingWithAssertion.java
@@ -1,0 +1,41 @@
+package outcomes;
+
+import mock.WithoutException;
+import org.hyperskill.hstest.dev.stage.MainMethodTest;
+import org.hyperskill.hstest.dev.testcase.CheckResult;
+import org.hyperskill.hstest.dev.testcase.TestCase;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class FatalErrorDuringCheckingWithAssertion extends MainMethodTest {
+
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+
+    public FatalErrorDuringCheckingWithAssertion() throws Exception {
+        super(WithoutException.class);
+    }
+
+    @Before
+    public void before() {
+        exception.expect(AssertionError.class);
+        exception.expectMessage("Fatal error in test #1, please send the report to Hyperskill team.");
+    }
+
+    @Override
+    public List<TestCase> generateTestCases() {
+        return Arrays.asList(
+                new TestCase()
+        );
+    }
+
+    @Override
+    public CheckResult check(String reply, Object clue) {
+        assert false;
+        return CheckResult.TRUE;
+    }
+}

--- a/src/test/java/outcomes/FatalErrorGeneratingTestsWithAssertion.java
+++ b/src/test/java/outcomes/FatalErrorGeneratingTestsWithAssertion.java
@@ -1,0 +1,41 @@
+package outcomes;
+
+import mock.WithoutException;
+import org.hyperskill.hstest.dev.stage.MainMethodTest;
+import org.hyperskill.hstest.dev.testcase.CheckResult;
+import org.hyperskill.hstest.dev.testcase.TestCase;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class FatalErrorGeneratingTestsWithAssertion extends MainMethodTest {
+
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+
+    public FatalErrorGeneratingTestsWithAssertion() throws Exception {
+        super(WithoutException.class);
+    }
+
+    @Before
+    public void before() {
+        exception.expect(AssertionError.class);
+        exception.expectMessage("Fatal error during testing, please send the report to Hyperskill team.");
+    }
+
+    @Override
+    public List<TestCase> generateTestCases() {
+        assert false;
+        return Arrays.asList(
+                new TestCase()
+        );
+    }
+
+    @Override
+    public CheckResult check(String reply, Object clue) {
+        return CheckResult.TRUE;
+    }
+}


### PR DESCRIPTION
This resolves #32.

Is it OK to just add `Error` in catch?