### PR TITLE
Null check added when searching for class name with Kt twist

### DIFF
--- a/src/main/java/org/hyperskill/hstest/stage/SpringTest.java
+++ b/src/main/java/org/hyperskill/hstest/stage/SpringTest.java
@@ -160,11 +160,9 @@ public abstract class SpringTest extends StageTest<Object> {
                     .stream().map(Class::getCanonicalName)
                     .collect(Collectors.toList());
             for (String name : allNameOfClasses) {
-                if (name != null) {
-                    if (name.endsWith("Kt")) {
-                        isKotlin = true;
-                        break;
-                    }
+                if (name != null && name.endsWith("Kt")) {
+                    isKotlin = true;
+                    break;
                 }
             }
 

--- a/src/main/java/org/hyperskill/hstest/stage/SpringTest.java
+++ b/src/main/java/org/hyperskill/hstest/stage/SpringTest.java
@@ -189,7 +189,8 @@ public abstract class SpringTest extends StageTest<Object> {
             } else {
                 List<Class<?>> allClassesFromPackage = ReflectionUtils.getAllClassesFromPackage("");
                 allClassesFromPackage.forEach(it -> {
-                    if (it.getCanonicalName().endsWith("Kt")
+                    if (it != null 
+                        && it.getCanonicalName().endsWith("Kt")
                             && ReflectionUtils.hasMainMethod(it)
                             && !springRunning) {
                         try {

--- a/src/main/java/org/hyperskill/hstest/stage/SpringTest.java
+++ b/src/main/java/org/hyperskill/hstest/stage/SpringTest.java
@@ -160,9 +160,11 @@ public abstract class SpringTest extends StageTest<Object> {
                     .stream().map(Class::getCanonicalName)
                     .collect(Collectors.toList());
             for (String name : allNameOfClasses) {
-                if (name.endsWith("Kt")) {
-                    isKotlin = true;
-                    break;
+                if (name != null) {
+                    if (name.endsWith("Kt")) {
+                        isKotlin = true;
+                        break;
+                    }
                 }
             }
 

--- a/src/main/java/org/hyperskill/hstest/stage/SpringTest.java
+++ b/src/main/java/org/hyperskill/hstest/stage/SpringTest.java
@@ -189,7 +189,7 @@ public abstract class SpringTest extends StageTest<Object> {
             } else {
                 List<Class<?>> allClassesFromPackage = ReflectionUtils.getAllClassesFromPackage("");
                 allClassesFromPackage.forEach(it -> {
-                    if (it != null 
+                    if (it.getCanonicalName() != null
                         && it.getCanonicalName().endsWith("Kt")
                             && ReflectionUtils.hasMainMethod(it)
                             && !springRunning) {


### PR DESCRIPTION
Null check added when searching for class name with Kt twist in the method startSpring

Task: [#HSPC-65](https://vyahhi.myjetbrains.com/youtrack/issue/HSPC-65)

**Dependencies**
- !

**Reviewers**
- [ ] @inuur 

**Description**
